### PR TITLE
feat: add RuleGroup<T> with support for AND, OR, NOT logic

### DIFF
--- a/RuleEngine/src/RuleEngine.Domain/Core/Enums/LogicalOperator.cs
+++ b/RuleEngine/src/RuleEngine.Domain/Core/Enums/LogicalOperator.cs
@@ -1,0 +1,9 @@
+﻿namespace RuleEngine.Domain.Core.Enums
+{
+    public enum LogicalOperator
+    {
+        And,
+        Or,
+        Not
+    }
+}

--- a/RuleEngine/src/RuleEngine.Domain/Core/Interfaces/IRuleNode.cs
+++ b/RuleEngine/src/RuleEngine.Domain/Core/Interfaces/IRuleNode.cs
@@ -1,6 +1,6 @@
 ﻿namespace RuleEngine.Domain.Core.Interfaces
 {
-    public interface IRuleComponent<T>
+    public interface IRuleNode<T>
     {
         bool Evaluate(T input);
         string Name { get; }

--- a/RuleEngine/src/RuleEngine.Domain/Core/Rules/Rule.cs
+++ b/RuleEngine/src/RuleEngine.Domain/Core/Rules/Rule.cs
@@ -2,7 +2,7 @@
 
 namespace RuleEngine.Domain.Core.Rules
 {
-    public class Rule<T> : IRuleComponent<T>
+    public class Rule<T> : IRuleNode<T>
     {
         public string Name { get; }
         public string? Expression { get; }

--- a/RuleEngine/tests/RuleEngine.Application.Tests/RuleGroupTests.cs
+++ b/RuleEngine/tests/RuleEngine.Application.Tests/RuleGroupTests.cs
@@ -1,0 +1,44 @@
+﻿using RuleEngine.Domain.Core.Rules;
+
+namespace RuleEngine.Tests
+{
+    public class RuleGroupTests
+    {
+        public class DummyContext
+        {
+            public int Value { get; set; }
+        }
+
+        [Fact]
+        public void Should_Evaluate_AND_Group_Correctly()
+        {
+            var rule1 = Rule<DummyContext>.Create("GreaterThan5", x => x.Value > 5);
+            var rule2 = Rule<DummyContext>.Create("LessThan10", x => x.Value < 10);
+            var group = RuleGroup<DummyContext>.And("Group1", rule1, rule2);
+
+            var context = new DummyContext { Value = 7 };
+            Assert.True(group.Evaluate(context));
+        }
+
+        [Fact]
+        public void Should_Evaluate_OR_Group_Correctly()
+        {
+            var rule1 = Rule<DummyContext>.Create("LessThan3", x => x.Value < 3);
+            var rule2 = Rule<DummyContext>.Create("GreaterThan10", x => x.Value > 10);
+            var group = RuleGroup<DummyContext>.Or("Group2", rule1, rule2);
+
+            var context = new DummyContext { Value = 12 };
+            Assert.True(group.Evaluate(context));
+        }
+
+        [Fact]
+        public void Should_Evaluate_NOT_Group_Correctly()
+        {
+            var rule = Rule<DummyContext>.Create("Equals5", x => x.Value == 5);
+            var notGroup = RuleGroup<DummyContext>.Not("Not5", rule);
+
+            var context = new DummyContext { Value = 6 };
+            Assert.True(notGroup.Evaluate(context));
+        }
+    }
+}


### PR DESCRIPTION
- Introduced IRuleNode<T> as a common interface for Rule<T> and RuleGroup<T>
- Updated Rule<T> to implement IRuleNode<T> and expose factory methods only
- Implemented RuleGroup<T> to support composite logical evaluations
- Added LogicalOperator enum to define AND, OR, NOT operations
- Created RuleGroupTests to validate composite rule evaluation
- Replaced direct constructor usage with Rule<T>.Create(...) in tests to match private constructor visibility