### PR TITLE
feat: add recursive Compile(IRuleNode<T>) support to RuleCompilerService

### DIFF
--- a/RuleEngine/src/RuleEngine.Application/DTOs/RuleTreeDto.cs
+++ b/RuleEngine/src/RuleEngine.Application/DTOs/RuleTreeDto.cs
@@ -1,0 +1,18 @@
+﻿using RuleEngine.Application.Enums;
+using RuleEngine.Domain.Core.Enums;
+
+namespace RuleEngine.Application.DTOs
+{
+    public class RuleTreeDto
+    {
+        public RuleTreeNodeType Type { get; set; } = RuleTreeNodeType.Rule;
+        public string Name { get; set; } = string.Empty;
+
+        // For Rule
+        public string? Expression { get; set; }
+
+        // For Group
+        public LogicalOperator? Operator { get; set; }
+        public List<RuleTreeDto>? Children { get; set; }
+    }
+}

--- a/RuleEngine/src/RuleEngine.Application/Enums/RuleTreeNodeType.cs
+++ b/RuleEngine/src/RuleEngine.Application/Enums/RuleTreeNodeType.cs
@@ -1,0 +1,8 @@
+﻿namespace RuleEngine.Application.Enums
+{
+    public enum RuleTreeNodeType
+    {
+        Rule,
+        Group
+    }
+}

--- a/RuleEngine/src/RuleEngine.Application/Services/RuleCompilerService.cs
+++ b/RuleEngine/src/RuleEngine.Application/Services/RuleCompilerService.cs
@@ -1,7 +1,8 @@
-﻿using System.Linq.Dynamic.Core;
-using System.Linq.Expressions;
-using RuleEngine.Application.Interfaces;
+﻿using RuleEngine.Application.Interfaces;
+using RuleEngine.Domain.Core.Interfaces;
 using RuleEngine.Domain.Core.Rules;
+using System.Linq.Dynamic.Core;
+using System.Linq.Expressions;
 
 namespace RuleEngine.Application.Services
 {
@@ -36,5 +37,43 @@ namespace RuleEngine.Application.Services
                 }
             }
         }
+
+        public void Compile(IRuleNode<T> node)
+        {
+            switch (node)
+            {
+                case Rule<T> rule when rule.IsExpressionRule && rule.CompiledCondition == null:
+                    try
+                    {
+                        var parameter = Expression.Parameter(typeof(T), "x");
+                        var lambda = DynamicExpressionParser.ParseLambda(
+                            new[] { parameter },
+                            typeof(bool),
+                            rule.Expression!
+                        );
+
+                        var compiled = (Func<T, bool>)lambda.Compile();
+
+                        typeof(Rule<T>)
+                            .GetProperty(nameof(Rule<T>.CompiledCondition))!
+                            .SetValue(rule, compiled);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new InvalidOperationException(
+                            $"Error compiling rule '{rule.Name}': {ex.Message}", ex);
+                    }
+                    break;
+
+                case RuleGroup<T> group:
+                    foreach (var child in group.Rules)
+                    {
+                        Compile(child); // Recursive
+                    }
+                    break;
+            }
+        }
+
+
     }
 }

--- a/RuleEngine/src/RuleEngine.Application/Services/RuleTreeParser.cs
+++ b/RuleEngine/src/RuleEngine.Application/Services/RuleTreeParser.cs
@@ -1,0 +1,38 @@
+﻿using RuleEngine.Application.DTOs;
+using RuleEngine.Application.Enums;
+using RuleEngine.Domain.Core.Enums;
+using RuleEngine.Domain.Core.Interfaces;
+using RuleEngine.Domain.Core.Rules;
+
+namespace RuleEngine.Application.Services
+{
+    public static class RuleTreeParser<T>
+    {
+        public static IRuleNode<T> Parse(RuleTreeDto dto)
+        {
+            switch (dto.Type)
+            {
+                case RuleTreeNodeType.Rule:
+                    if (string.IsNullOrWhiteSpace(dto.Expression))
+                        throw new ArgumentException("Expression is required for rule nodes");
+                    return Rule<T>.FromExpression(dto.Name, dto.Expression);
+
+                case RuleTreeNodeType.Group:
+                    if (dto.Children == null || dto.Children.Count == 0)
+                        throw new ArgumentException("Group node must contain children");
+
+                    var nodes = dto.Children.Select(Parse).ToArray();
+                    return dto.Operator switch
+                    {
+                        LogicalOperator.And => RuleGroup<T>.And(dto.Name, nodes),
+                        LogicalOperator.Or => RuleGroup<T>.Or(dto.Name, nodes),
+                        LogicalOperator.Not when nodes.Length == 1 => RuleGroup<T>.Not(dto.Name, nodes[0]),
+                        _ => throw new ArgumentException($"Invalid or unsupported operator: {dto.Operator}")
+                    };
+
+                default:
+                    throw new ArgumentException($"Unknown rule type: {dto.Type}");
+            }
+        }
+    }
+}

--- a/RuleEngine/src/RuleEngine.Domain/Core/Rules/LogicalOperator.cs
+++ b/RuleEngine/src/RuleEngine.Domain/Core/Rules/LogicalOperator.cs
@@ -1,9 +1,0 @@
-﻿namespace RuleEngine.Domain.Core.Rules
-{
-    public enum LogicalOperator
-    {
-        And,
-        Or,
-        Not
-    }
-}

--- a/RuleEngine/src/RuleEngine.Domain/Core/Rules/RuleGroup.cs
+++ b/RuleEngine/src/RuleEngine.Domain/Core/Rules/RuleGroup.cs
@@ -1,4 +1,5 @@
-﻿using RuleEngine.Domain.Core.Interfaces;
+﻿using RuleEngine.Domain.Core.Enums;
+using RuleEngine.Domain.Core.Interfaces;
 
 namespace RuleEngine.Domain.Core.Rules
 {

--- a/RuleEngine/tests/RuleEngine.Application.Tests/RuleTreeParserTests.cs
+++ b/RuleEngine/tests/RuleEngine.Application.Tests/RuleTreeParserTests.cs
@@ -1,0 +1,55 @@
+﻿// File: RuleTreeParserTests.cs
+using RuleEngine.Application.DTOs;
+using RuleEngine.Application.Enums;
+using RuleEngine.Application.Services;
+using RuleEngine.Domain.Core.Enums;
+using RuleEngine.Domain.Core.Rules;
+using Xunit;
+
+namespace RuleEngine.Application.Tests
+{
+    public class RuleTreeParserTests
+    {
+        public class DummyContext
+        {
+            public int Score { get; set; }
+        }
+
+        [Fact]
+        public void Should_Parse_And_Evaluate_RuleGroup_From_DTO()
+        {
+            var dto = new RuleTreeDto
+            {
+                Type = RuleTreeNodeType.Group,
+                Name = "MainGroup",
+                Operator = LogicalOperator.And,
+                Children = new List<RuleTreeDto>
+                {
+                    new RuleTreeDto
+                    {
+                        Type = RuleTreeNodeType.Rule,
+                        Name = "MinScore",
+                        Expression = "Score >= 50"
+                    },
+                    new RuleTreeDto
+                    {
+                        Type = RuleTreeNodeType.Rule,
+                        Name = "MaxScore",
+                        Expression = "Score <= 100"
+                    }
+                }
+            };
+
+            var ruleTree = RuleTreeParser<DummyContext>.Parse(dto);
+
+            // Compile expression-based rules
+            var compiler = new RuleCompilerService<DummyContext>();
+            compiler.Compile(ruleTree);
+
+            var context = new DummyContext { Score = 75 };
+            var result = ruleTree.Evaluate(context);
+
+            Assert.True(result);
+        }
+    }
+}


### PR DESCRIPTION
- Added overload to RuleCompilerService<T> to compile both simple rules and nested RuleGroup<T> structures
- Ensures all expression-based rules are properly compiled before evaluation
- Enables support for dynamic rule trees with composite logical operations (AND, OR, NOT)
- Fixed property name from 'Nodes' to 'Rules' in RuleGroup<T> during traversal